### PR TITLE
Fix incorrect remote bda and time_t bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,11 @@ Then you should see the examples and be able to include the library in your proj
 
 This works like a standard Arduino library. Here's a minimal example:
 
-```
+```c
+#include "esp32notifications.h"
+
 // Create an interface to the BLE notification library at the top of your sketch
 BLENotifications notifications;
-
-// Start looking for a device connection
-notifications.begin("BLEConnection device name");
 
 // This callback will be called when a Bluetooth LE connection is made or broken.
 // You can update the ESP 32's UI or take other action here.
@@ -74,13 +73,18 @@ void onBLEStateChanged(BLENotifications::State state) {
 }
 
 // Setup a callback for when a notification arrives
-void onNotificationArrived(const ArduinoNotification * notification, Notification * rawData) {
+void onNotificationArrived(const ArduinoNotification * notification, const Notification * rawData) {
     Serial.println(notification->title);
 }
 
-// Register the callback to be informed when a notification arrives
-notifications.setConnectionStateChangedCallback(onBLEStateChanged);
-notifications.setNotificationCallback(onNotificationArrived);
+void setup() {
+  // Start looking for a device connection
+  notifications.begin("BLEConnection device name");
+
+  // Register the callback to be informed when a notification arrives
+  notifications.setConnectionStateChangedCallback(onBLEStateChanged);
+  notifications.setNotificationCallback(onNotificationArrived);
+}
 ```
 
 Note that the Espressif BLE libraries are very large, so you may need to increase your partition scheme to "Large" in the Arduino IDE.

--- a/examples/ble_connection/ble_connection.ino
+++ b/examples/ble_connection/ble_connection.ino
@@ -3,7 +3,6 @@
 
 // A simple example program to retrieve notifications from your device, and output them to the Serial console.
 
-
 // Header for this library, from https://www.github.com/Smartphone-Companions/ESP32-ANCS-Notifications.git
 #include "esp32notifications.h"
 
@@ -15,11 +14,11 @@
 #define HARDWARE_STANDARD
 
 #ifdef HARDWARE_STANDARD
-    #define BUTTON_A    25 // left button - use this GPIO pin
-    #define BUTTON_B    26 // center button - use this GPIO pin
-    #define BUTTON_C    27 // right button - use this GPIO pin
+#define BUTTON_A 25 // left button - use this GPIO pin
+#define BUTTON_B 26 // center button - use this GPIO pin
+#define BUTTON_C 27 // right button - use this GPIO pin
 #else
-    #error Hardware buttons not supported!
+#error Hardware buttons not supported!
 #endif
 
 //////////
@@ -33,22 +32,23 @@ uint32_t incomingCallNotificationUUID;
 
 // This callback will be called when a Bluetooth LE connection is made or broken.
 // You can update the ESP 32's UI or take other action here.
-void onBLEStateChanged(BLENotifications::State state) {
-  switch(state) {
-      case BLENotifications::StateConnected:
-          Serial.println("StateConnected - connected to a phone or tablet"); 
-          break;
+void onBLEStateChanged(BLENotifications::State state)
+{
+    switch (state)
+    {
+    case BLENotifications::StateConnected:
+        Serial.println("StateConnected - connected to a phone or tablet");
+        break;
 
-      case BLENotifications::StateDisconnected:
-          Serial.println("StateDisconnected - disconnected from a phone or tablet"); 
-          /* We need to startAdvertising on disconnection, otherwise the ESP 32 will now be invisible.
-          IMO it would make sense to put this in the library to happen automatically, but some people in the Espressif forums
-          were requesting that they would like manual control over re-advertising.*/
-          notifications.startAdvertising(); 
-          break; 
-  }
+    case BLENotifications::StateDisconnected:
+        Serial.println("StateDisconnected - disconnected from a phone or tablet");
+        /* We need to startAdvertising on disconnection, otherwise the ESP 32 will now be invisible.
+        IMO it would make sense to put this in the library to happen automatically, but some people in the Espressif forums
+        were requesting that they would like manual control over re-advertising.*/
+        notifications.startAdvertising();
+        break;
+    }
 }
-
 
 // A notification arrived from the mobile device, ie a social media notification or incoming call.
 // parameters:
@@ -56,48 +56,52 @@ void onBLEStateChanged(BLENotifications::State state) {
 //                  pointer to this data - it will be destroyed after this function.
 //  - rawNotificationData: a pointer to the underlying data. It contains the same information, but is
 //                         not beginner-friendly. For advanced use-cases.
-void onNotificationArrived(const ArduinoNotification * notification, const Notification * rawNotificationData) {
-    Serial.print("Got notification: ");   
-    Serial.println(notification->title); // The title, ie name of who sent the message
-    Serial.println(notification->message); // The detail, ie "be home for dinner at 7".
-    Serial.println(notification->type);  // Which app sent it
-    Serial.println(notifications.getNotificationCategoryDescription(notification->category));  // ie "social media"
-    Serial.println(notification->categoryCount); // How may other notifications are there from this app (ie badge number)
-    if (notification->category == CategoryIDIncomingCall) {
-		// If this is an incoming call, store it so that we can later send a user action.
+void onNotificationArrived(const ArduinoNotification *notification, const Notification *rawNotificationData)
+{
+    Serial.print("Got notification: ");
+    Serial.println(notification->title);                                                      // The title, ie name of who sent the message
+    Serial.println(notification->message);                                                    // The detail, ie "be home for dinner at 7".
+    Serial.println(notification->type);                                                       // Which app sent it
+    Serial.println(notifications.getNotificationCategoryDescription(notification->category)); // ie "social media"
+    Serial.println(notification->categoryCount);                                              // How may other notifications are there from this app (ie badge number)
+    if (notification->category == CategoryIDIncomingCall)
+    {
+        // If this is an incoming call, store it so that we can later send a user action.
         incomingCallNotificationUUID = notification->uuid;
-        Serial.println("--- INCOMING CALL: PRESS A TO ACCEPT, C TO REJECT ---"); 
+        Serial.println("--- INCOMING CALL: PRESS A TO ACCEPT, C TO REJECT ---");
     }
-    else {
+    else
+    {
         incomingCallNotificationUUID = 0; // Make invalid - no incoming call
     }
 }
 
-
 // A notification was cleared
-void onNotificationRemoved(const ArduinoNotification * notification, const Notification * rawNotificationData) {
-     Serial.print("Removed notification: ");   
-     Serial.println(notification->title);
-     Serial.println(notification->message);
-     Serial.println(notification->type);  
+void onNotificationRemoved(const ArduinoNotification *notification, const Notification *rawNotificationData)
+{
+    Serial.print("Removed notification: ");
+    Serial.println(notification->title);
+    Serial.println(notification->message);
+    Serial.println(notification->type);
 }
 
-
 // Standard Arduino function which is called once when the device first starts up
-void setup() {
-  // Button configuration. It is usual to have buttons configured as INPUT_PULLUP in the hardware design,
-  // but check the details for your specific device 
-  pinMode(BUTTON_A, INPUT_PULLUP);
-  pinMode(BUTTON_B, INPUT_PULLUP);
-  pinMode(BUTTON_C, INPUT_PULLUP);
+void setup()
+{
+    // Button configuration. It is usual to have buttons configured as INPUT_PULLUP in the hardware design,
+    // but check the details for your specific device
+    pinMode(BUTTON_A, INPUT_PULLUP);
+    pinMode(BUTTON_B, INPUT_PULLUP);
+    pinMode(BUTTON_C, INPUT_PULLUP);
 
     Serial.begin(115200);
-    while(!Serial) {
+    while (!Serial)
+    {
         delay(10);
     }
 
     Serial.println("ESP32-ANCS-Notifications Example");
-    Serial.println("------------------------------------------");    
+    Serial.println("------------------------------------------");
 
     // Set up the BLENotification library
     notifications.begin("BLEConnection device name");
@@ -106,18 +110,21 @@ void setup() {
     notifications.setRemovedCallback(onNotificationRemoved);
 }
 
-
 // Standard Arduino function that is called in an endless loop after setup
-void loop() {   
-    if (incomingCallNotificationUUID > 0) {
-		// Check to see if the user has pressed an action button
-	    if (digitalRead(BUTTON_A) == LOW) {
-	      Serial.println("Positive action."); 
-	        notifications.actionPositive(incomingCallNotificationUUID);
-	    }
-	    else if (digitalRead(BUTTON_C) == LOW) {
-	      Serial.println("Negative action."); 
-	        notifications.actionNegative(incomingCallNotificationUUID);
-	    }
+void loop()
+{
+    if (incomingCallNotificationUUID > 0)
+    {
+        // Check to see if the user has pressed an action button
+        if (digitalRead(BUTTON_A) == LOW)
+        {
+            Serial.println("Positive action.");
+            notifications.actionPositive(incomingCallNotificationUUID);
+        }
+        else if (digitalRead(BUTTON_C) == LOW)
+        {
+            Serial.println("Negative action.");
+            notifications.actionNegative(incomingCallNotificationUUID);
+        }
     }
 }

--- a/src/ancs_ble_client.cpp
+++ b/src/ancs_ble_client.cpp
@@ -22,249 +22,259 @@ const BLEUUID controlPointCharacteristicUUID("69D1D8F3-45E1-49A8-9821-9BBDFDAAD9
 const BLEUUID dataSourceCharacteristicUUID("22EAC6E9-24D6-4BB5-BE44-B36ACE7C7BFB");
 const BLEUUID ancsServiceUUID("7905F431-B5CE-4E99-A40F-4B1E122D00D0");
 
-
-static ANCSBLEClient * sharedInstance;
+static ANCSBLEClient *sharedInstance;
 
 static void dataSourceNotifyCallback(
-  BLERemoteCharacteristic* pDataSourceCharacteristic,
-  uint8_t* pData,
-  size_t length,
-  bool isNotify) {
-	 ESP_LOGD(LOG_TAG, "dataSourceNotifyCallback");
+		BLERemoteCharacteristic *pDataSourceCharacteristic,
+		uint8_t *pData,
+		size_t length,
+		bool isNotify)
+{
+	ESP_LOGD(LOG_TAG, "dataSourceNotifyCallback");
 	sharedInstance->onDataSourceNotify(pDataSourceCharacteristic, pData, length, isNotify);
 }
 
-
 static void notificationSourceNotifyCallback(
-  BLERemoteCharacteristic* pNotificationSourceCharacteristic,
-  uint8_t* pData,
-  size_t length,
-  bool isNotify)
+		BLERemoteCharacteristic *pNotificationSourceCharacteristic,
+		uint8_t *pData,
+		size_t length,
+		bool isNotify)
 {
 	ESP_LOGD(LOG_TAG, "notificationSourceNotifyCallback");
-	
+
 	sharedInstance->onNotificationSourceNotify(pNotificationSourceCharacteristic, pData, length, isNotify);
 }
 
-
 ANCSBLEClient::ANCSBLEClient()
-	: notificationCB(nullptr)
-	, removedCB(nullptr)
-	, pControlPointCharacteristic(nullptr)
+		: notificationCB(nullptr), removedCB(nullptr), pControlPointCharacteristic(nullptr)
 {
 	assert(sharedInstance == nullptr);
-	sharedInstance = this;  
+	sharedInstance = this;
 	notificationQueue = new ANCSNotificationQueue();
 }
 
-
-ANCSBLEClient::~ANCSBLEClient() {
+ANCSBLEClient::~ANCSBLEClient()
+{
 	sharedInstance = nullptr;
 }
 
-void ANCSBLEClient::startClientTask(void * params) {
+void ANCSBLEClient::startClientTask(void *params)
+{
 	ESP_LOGD(LOG_TAG, "Starting client");
-		const BLEAddress* address = (BLEAddress*)params;
-		sharedInstance->setup(address);
+	const BLEAddress *address = (BLEAddress *)params;
+	sharedInstance->setup(address);
 
-		ANCSNotificationQueue * queue = sharedInstance->notificationQueue;
-	    while (1)
-	    {
-	        if (queue->pendingNotificationExists()) {
+	ANCSNotificationQueue *queue = sharedInstance->notificationQueue;
+	while (1)
+	{
+		if (queue->pendingNotificationExists())
+		{
 			Notification pending = queue->getNextPendingNotification();
-	          ESP_LOGD(LOG_TAG, "retriveNotificationData: %d", pending.uuid);
-	          sharedInstance->retrieveExtraNotificationData(pending);
-	        }
-	        delay(500);
-	    }
+			ESP_LOGD(LOG_TAG, "retriveNotificationData: %d", pending.uuid);
+			sharedInstance->retrieveExtraNotificationData(pending);
+		}
+		delay(500);
+	}
 }
 
+void ANCSBLEClient::setup(const BLEAddress *address)
+{
+	BLEClient *pClient = BLEDevice::createClient();
+	BLEDevice::setEncryptionLevel(ESP_BLE_SEC_ENCRYPT);
+	BLEDevice::setSecurityCallbacks(new NotificationSecurityCallbacks()); // @todo memory leak?
 
-void ANCSBLEClient::setup(const BLEAddress * address) {
-    BLEClient*  pClient  = BLEDevice::createClient();
-    BLEDevice::setEncryptionLevel(ESP_BLE_SEC_ENCRYPT);
-    BLEDevice::setSecurityCallbacks(new NotificationSecurityCallbacks()); // @todo memory leak?
+	BLESecurity *pSecurity = new BLESecurity();
+	pSecurity->setAuthenticationMode(ESP_LE_AUTH_REQ_SC_BOND);
+	pSecurity->setCapability(ESP_IO_CAP_IO);
+	pSecurity->setRespEncryptionKey(ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK);
+	// Connect to the remove BLE Server.
+	pClient->connect(*address);
 
-    BLESecurity *pSecurity = new BLESecurity();
-    pSecurity->setAuthenticationMode(ESP_LE_AUTH_REQ_SC_BOND);
-    pSecurity->setCapability(ESP_IO_CAP_IO);
-    pSecurity->setRespEncryptionKey(ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK);
-    // Connect to the remove BLE Server.
-    pClient->connect(*address);
+	/** BEGIN ANCS SERVICE **/
+	// Obtain a reference to the service we are after in the remote BLE server.
+	BLERemoteService *pAncsService = pClient->getService(ancsServiceUUID);
+	if (pAncsService == nullptr)
+	{
+		ESP_LOGW(LOG_TAG, "Failed to find service UUID ancsServiceUUID.");
+		return;
+	}
+	// Obtain a reference to the characteristic in the service of the remote BLE server.
+	BLERemoteCharacteristic *pNotificationSourceCharacteristic = pAncsService->getCharacteristic(notificationSourceCharacteristicUUID);
+	if (pNotificationSourceCharacteristic == nullptr)
+	{
+		ESP_LOGW(LOG_TAG, "Failed to find characteristic UUID notificationSourceCharacteristicUUID");
+		return;
+	}
+	// Obtain a reference to the characteristic in the service of the remote BLE server.
 
-    /** BEGIN ANCS SERVICE **/
-    // Obtain a reference to the service we are after in the remote BLE server.
-    BLERemoteService* pAncsService = pClient->getService(ancsServiceUUID);
-    if (pAncsService == nullptr) {
-        ESP_LOGW(LOG_TAG, "Failed to find service UUID ancsServiceUUID.");
-        return;
-    }
-    // Obtain a reference to the characteristic in the service of the remote BLE server.
-    BLERemoteCharacteristic* pNotificationSourceCharacteristic = pAncsService->getCharacteristic(notificationSourceCharacteristicUUID);
-    if (pNotificationSourceCharacteristic == nullptr) {
-        ESP_LOGW(LOG_TAG, "Failed to find characteristic UUID notificationSourceCharacteristicUUID");
-        return;
-    }        
-    // Obtain a reference to the characteristic in the service of the remote BLE server.
-	
-    pControlPointCharacteristic = pAncsService->getCharacteristic(controlPointCharacteristicUUID);
-    if (pControlPointCharacteristic == nullptr) {
-        ESP_LOGW(LOG_TAG, "Failed to find characteristic UUID: controlPointCharacteristicUUID");
-        return;
-    }        
-    // Obtain a reference to the characteristic in the service of the remote BLE server.
-    BLERemoteCharacteristic* pDataSourceCharacteristic = pAncsService->getCharacteristic(dataSourceCharacteristicUUID);
-    if (pDataSourceCharacteristic == nullptr) {
-        ESP_LOGW(LOG_TAG, "Failed to find characteristic UUID dataSourceCharacteristicUUID");
-        return;
-    }        
-    const uint8_t v[]={0x1,0x0};
-    pDataSourceCharacteristic->registerForNotify(dataSourceNotifyCallback);
-    pDataSourceCharacteristic->getDescriptor(BLEUUID((uint16_t)0x2902))->writeValue((uint8_t*)v,2,true);
-    pNotificationSourceCharacteristic->registerForNotify(notificationSourceNotifyCallback);
-    pNotificationSourceCharacteristic->getDescriptor(BLEUUID((uint16_t)0x2902))->writeValue((uint8_t*)v,2,true);
+	pControlPointCharacteristic = pAncsService->getCharacteristic(controlPointCharacteristicUUID);
+	if (pControlPointCharacteristic == nullptr)
+	{
+		ESP_LOGW(LOG_TAG, "Failed to find characteristic UUID: controlPointCharacteristicUUID");
+		return;
+	}
+	// Obtain a reference to the characteristic in the service of the remote BLE server.
+	BLERemoteCharacteristic *pDataSourceCharacteristic = pAncsService->getCharacteristic(dataSourceCharacteristicUUID);
+	if (pDataSourceCharacteristic == nullptr)
+	{
+		ESP_LOGW(LOG_TAG, "Failed to find characteristic UUID dataSourceCharacteristicUUID");
+		return;
+	}
+	const uint8_t v[] = {0x1, 0x0};
+	pDataSourceCharacteristic->registerForNotify(dataSourceNotifyCallback);
+	pDataSourceCharacteristic->getDescriptor(BLEUUID((uint16_t)0x2902))->writeValue((uint8_t *)v, 2, true);
+	pNotificationSourceCharacteristic->registerForNotify(notificationSourceNotifyCallback);
+	pNotificationSourceCharacteristic->getDescriptor(BLEUUID((uint16_t)0x2902))->writeValue((uint8_t *)v, 2, true);
 }
 
-BLEUUID ANCSBLEClient::getAncsServiceUUID() {
+BLEUUID ANCSBLEClient::getAncsServiceUUID()
+{
 	return ancsServiceUUID;
 }
 
-
-void ANCSBLEClient::setNotificationArrivedCallback(ble_notification_arrived_t cbNotification) {
+void ANCSBLEClient::setNotificationArrivedCallback(ble_notification_arrived_t cbNotification)
+{
 	notificationCB = cbNotification;
 }
 
-
-void ANCSBLEClient::setNotificationRemovedCallback(ble_notification_removed_t cbNotification) {
+void ANCSBLEClient::setNotificationRemovedCallback(ble_notification_removed_t cbNotification)
+{
 	removedCB = cbNotification;
 }
 
+void ANCSBLEClient::retrieveExtraNotificationData(Notification &pending)
+{
+	uint8_t uuid[4];
+	uint32_t notifyUUID = pending.uuid;
+	uuid[0] = notifyUUID;
+	uuid[1] = notifyUUID >> 8;
+	uuid[2] = notifyUUID >> 16;
+	uuid[3] = notifyUUID >> 24;
 
-void ANCSBLEClient::retrieveExtraNotificationData(Notification & pending) {
-	  uint8_t uuid[4];
-	  uint32_t notifyUUID = pending.uuid;
-	  uuid[0] = notifyUUID;
-	  uuid[1] = notifyUUID >> 8;
-	  uuid[2] = notifyUUID >> 16;
-	  uuid[3] = notifyUUID >> 24;
-	  
-	  
-      bool notificationAlreadyInQueue = notificationQueue->contains(pending.uuid);
-      if (notificationAlreadyInQueue == false) {
-          notificationQueue->addNotification(notifyUUID, pending, isIncomingCall(pending));
-      }
-	  
-	  const uint8_t vIdentifier[] = {0x0, uuid[0], uuid[1], uuid[2], uuid[3], ANCS::NotificationAttributeIDAppIdentifier};
-	  pControlPointCharacteristic->writeValue((uint8_t *)vIdentifier, 6, true);
-	  const uint8_t vTitle[] = {0x0, uuid[0], uuid[1], uuid[2], uuid[3], ANCS::NotificationAttributeIDTitle, 0x0, 0x10};
-	  pControlPointCharacteristic->writeValue((uint8_t *)vTitle, 8, true);
-	  const uint8_t vMessage[] = {0x0, uuid[0], uuid[1], uuid[2], uuid[3], ANCS::NotificationAttributeIDMessage, 0x0, 0x10};
-	  pControlPointCharacteristic->writeValue((uint8_t *)vMessage, 8, true);
-	  const uint8_t vDate[] = {0x0, uuid[0], uuid[1], uuid[2], uuid[3], ANCS::NotificationAttributeIDDate};
-	  pControlPointCharacteristic->writeValue((uint8_t *)vDate, 6, true);
+	bool notificationAlreadyInQueue = notificationQueue->contains(pending.uuid);
+	if (notificationAlreadyInQueue == false)
+	{
+		notificationQueue->addNotification(notifyUUID, pending, isIncomingCall(pending));
+	}
+
+	const uint8_t vIdentifier[] = {0x0, uuid[0], uuid[1], uuid[2], uuid[3], ANCS::NotificationAttributeIDAppIdentifier};
+	pControlPointCharacteristic->writeValue((uint8_t *)vIdentifier, 6, true);
+	const uint8_t vTitle[] = {0x0, uuid[0], uuid[1], uuid[2], uuid[3], ANCS::NotificationAttributeIDTitle, 0x0, 0x10};
+	pControlPointCharacteristic->writeValue((uint8_t *)vTitle, 8, true);
+	const uint8_t vMessage[] = {0x0, uuid[0], uuid[1], uuid[2], uuid[3], ANCS::NotificationAttributeIDMessage, 0x0, 0x10};
+	pControlPointCharacteristic->writeValue((uint8_t *)vMessage, 8, true);
+	const uint8_t vDate[] = {0x0, uuid[0], uuid[1], uuid[2], uuid[3], ANCS::NotificationAttributeIDDate};
+	pControlPointCharacteristic->writeValue((uint8_t *)vDate, 6, true);
 }
 
 void ANCSBLEClient::onDataSourceNotify(
-  BLERemoteCharacteristic* pNotificationSourceCharacteristic,
-  uint8_t* pData,
-  size_t length,
-  bool isNotify) {
-	
-    std::string message;
-	
-    uint32_t messageId = pData[4];
-    messageId = messageId << 8 | pData[3];
-    messageId = messageId << 16 | pData[2];
-    messageId = messageId << 24 | pData[1];
+		BLERemoteCharacteristic *pNotificationSourceCharacteristic,
+		uint8_t *pData,
+		size_t length,
+		bool isNotify)
+{
 
-    for (int i = 8; i < length; i++)
-    {
-      message += (char)pData[i];
-    }
+	std::string message;
+
+	uint32_t messageId = pData[4];
+	messageId = messageId << 8 | pData[3];
+	messageId = messageId << 16 | pData[2];
+	messageId = messageId << 24 | pData[1];
+
+	for (int i = 8; i < length; i++)
+	{
+		message += (char)pData[i];
+	}
 
 	ESP_LOGD(LOG_TAG, "ID: %d raw message: %s type==%d", messageId, message.c_str(), pData[5]);
 
-	Notification * notification = notificationQueue->getNotification(messageId);
+	Notification *notification = notificationQueue->getNotification(messageId);
 
-      switch (pData[5])
-      {
-        case ANCS::NotificationAttributeIDAppIdentifier:
-		    notification->type = message;
-			ESP_LOGD(LOG_TAG, "got type: %s", message.c_str());
-			break;
-        case 0x1:
-          notification->title = message;
-		  ESP_LOGD(LOG_TAG, "got title: %s", message.c_str());
-          break;
-        case 0x3:
-          notification->message = message;
-		  ESP_LOGD(LOG_TAG, "got message: %s", message.c_str());
-          break;
-      }
-      if (!notification->title.empty() && !notification->message.empty()) {
-		if (notificationCB && notification->isComplete == false) {
+	switch (pData[5])
+	{
+	case ANCS::NotificationAttributeIDAppIdentifier:
+		notification->type = message;
+		ESP_LOGD(LOG_TAG, "got type: %s", message.c_str());
+		break;
+	case 0x1:
+		notification->title = message;
+		ESP_LOGD(LOG_TAG, "got title: %s", message.c_str());
+		break;
+	case 0x3:
+		notification->message = message;
+		ESP_LOGD(LOG_TAG, "got message: %s", message.c_str());
+		break;
+	}
+	if (!notification->title.empty() && !notification->message.empty())
+	{
+		if (notificationCB && notification->isComplete == false)
+		{
 			ESP_LOGI(LOG_TAG, "got a full notification: %s - %s ", notification->title.c_str(), notification->message.c_str());
 			const ArduinoNotification arduinoNotification = ArduinoNotification(*notification);
 			notificationCB(&arduinoNotification, notification);
 		}
 		notification->isComplete = true;
-      }
+	}
 }
 
-bool ANCSBLEClient::isIncomingCall(const Notification & notification) const {
+bool ANCSBLEClient::isIncomingCall(const Notification &notification) const
+{
 	// @todo detect if it is a FaceTime or call by app? Or is category sufficient?
 	return notification.category == CategoryIDIncomingCall;
 }
-	
+
 void ANCSBLEClient::onNotificationSourceNotify(
-	  BLERemoteCharacteristic *pNotificationSourceCharacteristic,
-	  uint8_t *pData,
-	  size_t length,
-	  bool isNotify) {
-	  uint32_t messageId;
+		BLERemoteCharacteristic *pNotificationSourceCharacteristic,
+		uint8_t *pData,
+		size_t length,
+		bool isNotify)
+{
+	uint32_t messageId;
 
-	  messageId = pData[7];
-	  messageId = messageId << 8 | pData[6];
-	  messageId = messageId << 16 | pData[5];
-	  messageId = messageId << 24 | pData[4];
+	messageId = pData[7];
+	messageId = messageId << 8 | pData[6];
+	messageId = messageId << 16 | pData[5];
+	messageId = messageId << 24 | pData[4];
 
-	if (pData[0] == ANCS::EventIDNotificationRemoved) {
+	if (pData[0] == ANCS::EventIDNotificationRemoved)
+	{
 		ESP_LOGI(LOG_TAG, "notification removed: %d", messageId);
 
-	    Notification * notification = notificationQueue->getNotification(messageId);
+		Notification *notification = notificationQueue->getNotification(messageId);
 
-	    if (isIncomingCall(*notification))
-	    {
-	      notificationQueue->addNotification(messageId, *notification, false);
-	      notificationQueue->removeCallNotification();
-	    }
-		
-		if (removedCB) {
+		if (isIncomingCall(*notification))
+		{
+			notificationQueue->addNotification(messageId, *notification, false);
+			notificationQueue->removeCallNotification();
+		}
+
+		if (removedCB)
+		{
 			const ArduinoNotification arduinoNotification = ArduinoNotification(*notification);
 			removedCB(&arduinoNotification, notification);
 		}
 	}
-	else if (pData[0] == ANCS::EventIDNotificationAdded) {
-	    ESP_LOGI(LOG_TAG, "notification added, type: %d", pData[2]);
+	else if (pData[0] == ANCS::EventIDNotificationAdded)
+	{
+		ESP_LOGI(LOG_TAG, "notification added, type: %d", pData[2]);
 		Notification pending;
 		pending.uuid = messageId;
 		pending.eventFlags = pData[1];
 		pending.category = NotificationCategory(pData[2]);
-		pending.categoryCount = pData[3]; 
-	    notificationQueue->addPendingNotification(pending);
+		pending.categoryCount = pData[3];
+		notificationQueue->addPendingNotification(pending);
 	}
 }
 
+void ANCSBLEClient::performAction(uint32_t notifyUUID, uint8_t actionID)
+{
 
-void ANCSBLEClient::performAction(uint32_t notifyUUID, uint8_t actionID) {
-	
-  uint8_t uuid[4];
-  uuid[0] = notifyUUID;
-  uuid[1] = notifyUUID >> 8;
-  uuid[2] = notifyUUID >> 16;
-  uuid[3] = notifyUUID >> 24;
-	
-  const uint8_t vPerformAction[] = {ANCS::CommandIDPerformNotificationAction, uuid[0], uuid[1], uuid[2], uuid[3], actionID};
-  pControlPointCharacteristic->writeValue((uint8_t *)vPerformAction, (sizeof(vPerformAction)/sizeof(vPerformAction[0])), true);
+	uint8_t uuid[4];
+	uuid[0] = notifyUUID;
+	uuid[1] = notifyUUID >> 8;
+	uuid[2] = notifyUUID >> 16;
+	uuid[3] = notifyUUID >> 24;
 
+	const uint8_t vPerformAction[] = {ANCS::CommandIDPerformNotificationAction, uuid[0], uuid[1], uuid[2], uuid[3], actionID};
+	pControlPointCharacteristic->writeValue((uint8_t *)vPerformAction, (sizeof(vPerformAction) / sizeof(vPerformAction[0])), true);
 }

--- a/src/ancs_ble_client.h
+++ b/src/ancs_ble_client.h
@@ -11,18 +11,18 @@ class BLEAddress;
 class BLERemoteCharacteristic;
 class ANCSNotificationQueue;
 
-
 #include "BLEUUID.h"
 
 /**
  * Internal module for creating and managing an ANCS client connection singleton.
  * This needs to run asynchronously as a FreeRTOS task.
  */
-class ANCSBLEClient {
+class ANCSBLEClient
+{
 public:
-   /**
-    * Become a BLE client to a remote BLE server. Pass in address of the server.
-    */
+	/**
+	 * Become a BLE client to a remote BLE server. Pass in address of the server.
+	 */
 	ANCSBLEClient();
 	virtual ~ANCSBLEClient();
 	void setNotificationArrivedCallback(ble_notification_arrived_t cbNotification);
@@ -32,39 +32,39 @@ public:
 
 public:
 	static BLEUUID getAncsServiceUUID(); // To be able to advertise it
-	
+
 	/**
 	 * Start the FreeRTOS task that handles the client connection.
 	 */
 	static void startClientTask(void *data);
-	
+
 public:
 	xTaskHandle clientTaskHandle;
-	
-	void onDataSourceNotify(BLERemoteCharacteristic*, uint8_t*, size_t, bool);
-	void onNotificationSourceNotify(BLERemoteCharacteristic*, uint8_t*, size_t, bool);
-	
+
+	void onDataSourceNotify(BLERemoteCharacteristic *, uint8_t *, size_t, bool);
+	void onNotificationSourceNotify(BLERemoteCharacteristic *, uint8_t *, size_t, bool);
+
 private:
-	void setup(const BLEAddress*);
-	
+	void setup(const BLEAddress *);
+
 	/**
 	 * A notification event only contains minimal information. We need to request the extra info
 	 * in a second BLE request, then fill in the data in our notification queue as it arrives.
 	 */
 	void retrieveExtraNotificationData(Notification &);
-	
+
 	/**
 	 * Check if this notification is a call event, by checking the triggering app type.
 	 * @return true if this is a an incoming call.
 	 */
-	bool isIncomingCall(const Notification & notification) const;
-	
-	ANCSNotificationQueue * notificationQueue;
-	
+	bool isIncomingCall(const Notification &notification) const;
+
+	ANCSNotificationQueue *notificationQueue;
+
 	ble_notification_arrived_t notificationCB;
 	ble_notification_removed_t removedCB;
-	
-	class BLERemoteCharacteristic* pControlPointCharacteristic;
+
+	class BLERemoteCharacteristic *pControlPointCharacteristic;
 };
 
 #endif // ANCS_BLE_CLIENT_H_

--- a/src/ancs_notification_queue.cpp
+++ b/src/ancs_notification_queue.cpp
@@ -3,28 +3,25 @@
 
 static char LOG_TAG[] = "ANCSNotificationQueue";
 
-
 void ANCSNotificationQueue::addPendingNotification(const Notification pending)
 {
   pendingNotification.push(pending);
   ESP_LOGD(LOG_TAG, "Add pending Notification, id: %d", pending.uuid);
 }
 
-
-bool ANCSNotificationQueue::pendingNotificationExists() {
-	return (pendingNotification.size() > 0);
+bool ANCSNotificationQueue::pendingNotificationExists()
+{
+  return (pendingNotification.size() > 0);
 }
-
 
 Notification ANCSNotificationQueue::getNextPendingNotification()
 {
-	assert(pendingNotification.size() > 0);
-    Notification pending = pendingNotification.top();
-    pendingNotification.pop();
-    ESP_LOGD(LOG_TAG, "Getting pending Notification %d", pending.uuid);
-    return pending;
+  assert(pendingNotification.size() > 0);
+  Notification pending = pendingNotification.top();
+  pendingNotification.pop();
+  ESP_LOGD(LOG_TAG, "Getting pending Notification %d", pending.uuid);
+  return pending;
 }
-
 
 void ANCSNotificationQueue::addNotification(uint32_t uuid, Notification notification, bool isCalling)
 {
@@ -44,19 +41,16 @@ void ANCSNotificationQueue::addNotification(uint32_t uuid, Notification notifica
   }
 };
 
-
 std::map<uint32_t, Notification> *ANCSNotificationQueue::getNotificationList()
 {
   return &notificationList;
 }
-
 
 bool ANCSNotificationQueue::contains(uint32_t uuid)
 {
   std::map<uint32_t, Notification>::iterator it = notificationList.find(uuid);
   return (it != notificationList.end()) | (callingNotification.uuid != 0);
 }
-
 
 Notification *ANCSNotificationQueue::getNotification(uint32_t uuid)
 {
@@ -68,24 +62,24 @@ Notification *ANCSNotificationQueue::getNotification(uint32_t uuid)
   return (it != notificationList.end()) ? &it->second : new Notification();
 }
 
-
 void ANCSNotificationQueue::removeCallNotification()
 {
   callingNotification.uuid = 0;
 }
 
-
-bool ANCSNotificationQueue::isCallingNotification() {
+bool ANCSNotificationQueue::isCallingNotification()
+{
   return (callingNotification.uuid != 0);
 }
 
-
-Notification *ANCSNotificationQueue::getCallingNotification() {
+Notification *ANCSNotificationQueue::getCallingNotification()
+{
   return &callingNotification;
 }
 
-
-void ANCSNotificationQueue::removeNotification(uint32_t uuid) {
+void ANCSNotificationQueue::removeNotification(uint32_t uuid)
+{
   std::map<uint32_t, Notification>::iterator it = notificationList.find(uuid);
-  if (it != notificationList.end()) notificationList.erase(it);
+  if (it != notificationList.end())
+    notificationList.erase(it);
 }

--- a/src/ancs_notification_queue.h
+++ b/src/ancs_notification_queue.h
@@ -7,40 +7,40 @@
 #include <stack>
 #include <time.h>
 
-
 #include "ble_notification.h"
 
 /**
  * A variable-length queue of notifications.
  * Also contains a special "calling notification", which represents an incoming call.
  */
-class ANCSNotificationQueue{
-    public:		
-        void addPendingNotification(const Notification pending);
-		bool pendingNotificationExists();
-        Notification getNextPendingNotification();
-		
-		/**
-		 * Add notification to the queue.
-		 */
-        void addNotification(uint32_t uuid, Notification notification, bool isCalling);
-        void removeNotification(uint32_t uuid);
-        void removeCallNotification();
-		
-		/**
-		 * Is notification in queue.
-		 * @return true if in queue.
-		 */
-        bool contains(uint32_t uuid);
-        bool isCallingNotification();
-        Notification *getCallingNotification();
-        Notification *getNotification(uint32_t uuid);
-        std::map<uint32_t, Notification> *getNotificationList();
-        
-    private:
-        static const int notificationListSize = 32;
-        std::map<uint32_t, Notification> notificationList;
-        std::stack<Notification> pendingNotification; /**< Goes into a stack first, before we fetch detailed info into the queue. */
-        Notification callingNotification;
+class ANCSNotificationQueue
+{
+public:
+    void addPendingNotification(const Notification pending);
+    bool pendingNotificationExists();
+    Notification getNextPendingNotification();
+
+    /**
+     * Add notification to the queue.
+     */
+    void addNotification(uint32_t uuid, Notification notification, bool isCalling);
+    void removeNotification(uint32_t uuid);
+    void removeCallNotification();
+
+    /**
+     * Is notification in queue.
+     * @return true if in queue.
+     */
+    bool contains(uint32_t uuid);
+    bool isCallingNotification();
+    Notification *getCallingNotification();
+    Notification *getNotification(uint32_t uuid);
+    std::map<uint32_t, Notification> *getNotificationList();
+
+private:
+    static const int notificationListSize = 32;
+    std::map<uint32_t, Notification> notificationList;
+    std::stack<Notification> pendingNotification; /**< Goes into a stack first, before we fetch detailed info into the queue. */
+    Notification callingNotification;
 };
 #endif

--- a/src/ble_notification.h
+++ b/src/ble_notification.h
@@ -29,68 +29,67 @@ typedef enum
     CategoryIDEntertainment = 11
 } NotificationCategory;
 
-namespace ANCS { // Enums specific to ANCS. The others we can reuse for Android
+namespace ANCS
+{ // Enums specific to ANCS. The others we can reuse for Android
 
-typedef enum
-{
-    EventIDNotificationAdded = 0,
-    EventIDNotificationModified = 1,
-    EventIDNotificationRemoved = 2
-} event_id_t;
+    typedef enum
+    {
+        EventIDNotificationAdded = 0,
+        EventIDNotificationModified = 1,
+        EventIDNotificationRemoved = 2
+    } event_id_t;
 
-typedef enum
-{
-    NotificationActionPositive = 0,
-    NotificationActionNegative = 1
-} NotificationAction;
+    typedef enum
+    {
+        NotificationActionPositive = 0,
+        NotificationActionNegative = 1
+    } NotificationAction;
 
+    typedef enum
+    {
+        EventFlagSilent = (1 << 0),
+        EventFlagImportant = (1 << 1),
+        EventFlagPreExisting = (1 << 2),
+        EventFlagPositiveAction = (1 << 3),
+        EventFlagNegativeAction = (1 << 4)
+    } EventFlags;
 
-typedef enum
-{
-    EventFlagSilent = (1 << 0),
-    EventFlagImportant = (1 << 1),
-    EventFlagPreExisting = (1 << 2),
-    EventFlagPositiveAction = (1 << 3),
-    EventFlagNegativeAction = (1 << 4)
-} EventFlags;
+    typedef enum
+    {
+        CommandIDGetNotificationAttributes = 0,
+        CommandIDGetAppAttributes = 1,
+        CommandIDPerformNotificationAction = 2
+    } command_id_t;
 
-typedef enum
-{
-    CommandIDGetNotificationAttributes = 0,
-    CommandIDGetAppAttributes = 1,
-    CommandIDPerformNotificationAction = 2
-} command_id_t;
-
-
-typedef enum
-{
-    NotificationAttributeIDAppIdentifier = 0, /**< ie com.facebook.Messenger, or some other app */
-    NotificationAttributeIDTitle = 1,    // (Needs to be followed by a 2-bytes max length parameter)
-    NotificationAttributeIDSubtitle = 2, // (Needs to be followed by a 2-bytes max length parameter)
-    NotificationAttributeIDMessage = 3,  // (Needs to be followed by a 2-bytes max length parameter)
-    NotificationAttributeIDMessageSize = 4,
-    NotificationAttributeIDDate = 5,
-    NotificationAttributeIDPositiveActionLabel = 6,
-    NotificationAttributeIDNegativeActionLabel = 7
-} notification_attribute_id_t;
+    typedef enum
+    {
+        NotificationAttributeIDAppIdentifier = 0, /**< ie com.facebook.Messenger, or some other app */
+        NotificationAttributeIDTitle = 1,         // (Needs to be followed by a 2-bytes max length parameter)
+        NotificationAttributeIDSubtitle = 2,      // (Needs to be followed by a 2-bytes max length parameter)
+        NotificationAttributeIDMessage = 3,       // (Needs to be followed by a 2-bytes max length parameter)
+        NotificationAttributeIDMessageSize = 4,
+        NotificationAttributeIDDate = 5,
+        NotificationAttributeIDPositiveActionLabel = 6,
+        NotificationAttributeIDNegativeActionLabel = 7
+    } notification_attribute_id_t;
 
 };
-
 
 /**
  * A notification, usable by the caller of the library.
  */
-struct Notification {
+struct Notification
+{
     std::string title;
     std::string message;
     std::string type;
-	uint32_t eventFlags; /**< Bitfield of ANCS::EventFlags flags. */
+    uint32_t eventFlags; /**< Bitfield of ANCS::EventFlags flags. */
     time_t time;
     uint32_t uuid = 0;
     bool showed = false;
     bool isComplete = false;
-	NotificationCategory category; /**< If it is a call, social media, email, etc. */
-	uint8_t categoryCount; /**< Number of other notifications in this category (ie badge number count). */
+    NotificationCategory category; /**< If it is a call, social media, email, etc. */
+    uint8_t categoryCount;         /**< Number of other notifications in this category (ie badge number count). */
 };
 
 /**
@@ -98,45 +97,44 @@ struct Notification {
  * Arduino strings. We still use Notification for the underlying logic, because of the heap fragmentation issues
  * with Arduino strings.
  */
-struct ArduinoNotification {
+struct ArduinoNotification
+{
     String title;
     String message;
     String type;
-	uint32_t eventFlags; /**< Bitfield of ANCS::EventFlags flags. */
+    uint32_t eventFlags; /**< Bitfield of ANCS::EventFlags flags. */
     time_t time;
     uint32_t uuid = 0;
     bool showed = false;
     bool isComplete = false;
-	NotificationCategory category; /**< If it is a call, social media, email, etc. */
-	uint8_t categoryCount; /**< Number of other notifications in this category (ie badge number count). */
-	
-	ArduinoNotification(const Notification & src) {
-		title = String(src.title.c_str());
-		message = String(src.message.c_str());
-		type = String(src.type.c_str());
-		eventFlags = src.eventFlags;
-		time = src.time;
-		uuid = src.uuid;
-		showed = src.showed;
-		isComplete = src.isComplete;
-		category = src.category;
-		categoryCount = src.categoryCount;
-	}
+    NotificationCategory category; /**< If it is a call, social media, email, etc. */
+    uint8_t categoryCount;         /**< Number of other notifications in this category (ie badge number count). */
+
+    ArduinoNotification(const Notification &src)
+    {
+        title = String(src.title.c_str());
+        message = String(src.message.c_str());
+        type = String(src.type.c_str());
+        eventFlags = src.eventFlags;
+        time = src.time;
+        uuid = src.uuid;
+        showed = src.showed;
+        isComplete = src.isComplete;
+        category = src.category;
+        categoryCount = src.categoryCount;
+    }
 };
 
 /**
  * Callback for when a notification arrives.
  * @param notification The notification that just arrived.
  */
-typedef void (*ble_notification_arrived_t)(const ArduinoNotification * notification, const Notification * rawNotificationData);
+typedef void (*ble_notification_arrived_t)(const ArduinoNotification *notification, const Notification *rawNotificationData);
 
 /**
  * Callback for when a notification was removed.
  * @param notification The notification that was removed.
  */
-typedef void (*ble_notification_removed_t)(const ArduinoNotification * notification, const Notification * rawNotificationData);
-
-
-
+typedef void (*ble_notification_removed_t)(const ArduinoNotification *notification, const Notification *rawNotificationData);
 
 #endif

--- a/src/ble_notification.h
+++ b/src/ble_notification.h
@@ -8,6 +8,7 @@
 
 #include <string>
 #include <WString.h> // Arduino string
+#include <time.h>
 
 /**
  * Notification category, based on ANCS values, but could also be used for Android.

--- a/src/ble_security.cpp
+++ b/src/ble_security.cpp
@@ -5,30 +5,34 @@
 
 static char LOG_TAG[] = "NotificationSecurityCallbacks";
 
-
-
-uint32_t NotificationSecurityCallbacks::onPassKeyRequest(){
+uint32_t NotificationSecurityCallbacks::onPassKeyRequest()
+{
     ESP_LOGI(LOG_TAG, "PassKeyRequest");
     return 123456;
 }
 
-void NotificationSecurityCallbacks::onPassKeyNotify(uint32_t pass_key){
+void NotificationSecurityCallbacks::onPassKeyNotify(uint32_t pass_key)
+{
     ESP_LOGI(LOG_TAG, "On passkey Notify number:%d", pass_key);
 }
 
-bool NotificationSecurityCallbacks::onSecurityRequest(){
+bool NotificationSecurityCallbacks::onSecurityRequest()
+{
     ESP_LOGI(LOG_TAG, "On Security Request");
     return true;
 }
 
-bool NotificationSecurityCallbacks::onConfirmPIN(uint32_t){
+bool NotificationSecurityCallbacks::onConfirmPIN(uint32_t)
+{
     ESP_LOGI(LOG_TAG, "On Confirmed Pin Request");
     return true;
 }
 
-void NotificationSecurityCallbacks::onAuthenticationComplete(esp_ble_auth_cmpl_t cmpl){
+void NotificationSecurityCallbacks::onAuthenticationComplete(esp_ble_auth_cmpl_t cmpl)
+{
     ESP_LOGI(LOG_TAG, "Starting BLE work!");
-    if(cmpl.success){
+    if (cmpl.success)
+    {
         uint16_t length;
         esp_ble_gap_get_whitelist_size(&length);
         ESP_LOGD(LOG_TAG, "size: %d", length);

--- a/src/ble_security.h
+++ b/src/ble_security.h
@@ -3,14 +3,15 @@
 
 #include "BLESecurity.h"
 
-class NotificationSecurityCallbacks : public BLESecurityCallbacks {
+class NotificationSecurityCallbacks : public BLESecurityCallbacks
+{
 
     uint32_t onPassKeyRequest();
 
     void onPassKeyNotify(uint32_t pass_key);
 
     bool onSecurityRequest();
-    
+
     bool onConfirmPIN(uint32_t);
 
     void onAuthenticationComplete(esp_ble_auth_cmpl_t cmpl);

--- a/src/esp32notifications.cpp
+++ b/src/esp32notifications.cpp
@@ -4,7 +4,7 @@
 // NKolban's original library has a setServiceSolicitation method. As of writing, this is not in the
 // Espressif core libs. If you are using NKolban's branch of the library, or if this moves into
 // the core libraries eventually, uncomment this.
-//#define BLE_LIB_HAS_SERVICE_SOLICITATION 
+// #define BLE_LIB_HAS_SERVICE_SOLICITATION
 
 #include "esp32notifications.h"
 #include "ancs_ble_client.h"
@@ -25,182 +25,207 @@ extern const BLEUUID ancsServiceUUID;
 
 #ifndef BLE_LIB_HAS_SERVICE_SOLICITATION
 // Use a static function, instead of doing a whole private implementation just for a this one small patch.
-static void setServiceSolicitation(class BLEAdvertisementData & advertisementData, BLEUUID uuid);
+static void setServiceSolicitation(class BLEAdvertisementData &advertisementData, BLEUUID uuid);
 #endif
 
-class MyServerCallbacks: public BLEServerCallbacks {
+class MyServerCallbacks : public BLEServerCallbacks
+{
 private:
-    struct gatts_connect_evt_param { // @todo include from sdk/include/bt/esp_gatts_api.h
-        uint16_t conn_id;               /*!< Connection id */
-        esp_bd_addr_t remote_bda;       /*!< Remote bluetooth device address */
-    } connect; 
-	
+	struct gatts_connect_evt_param
+	{														// @todo include from sdk/include/bt/esp_gatts_api.h
+		uint16_t conn_id;					/*!< Connection id */
+		esp_bd_addr_t remote_bda; /*!< Remote bluetooth device address */
+	} connect;
+
 public:
-	BLENotifications * instance;
-	
-	MyServerCallbacks(BLENotifications * parent)
-	 	: instance(parent) {
+	BLENotifications *instance;
+
+	MyServerCallbacks(BLENotifications *parent)
+			: instance(parent)
+	{
 	}
-	
-    void onConnect(BLEServer* pServer, esp_ble_gatts_cb_param_t *param) {
+
+	void onConnect(BLEServer *pServer, esp_ble_gatts_cb_param_t *param)
+	{
 		ESP_LOGI(LOG_TAG, "Device connected");
-		gatts_connect_evt_param * connectEventParam = (gatts_connect_evt_param *) param;
-        instance->client = new ANCSBLEClient(); // @todo memory leaks?
+		gatts_connect_evt_param *connectEventParam = (gatts_connect_evt_param *)param;
+		instance->client = new ANCSBLEClient(); // @todo memory leaks?
 		instance->client->setNotificationArrivedCallback(instance->cbNotification);
 		instance->client->setNotificationRemovedCallback(instance->cbRemoved);
-		//instance->client->setStackSize(50000);
-	    ::xTaskCreatePinnedToCore(&ANCSBLEClient::startClientTask, "ClientTask", 10000, new BLEAddress(connectEventParam->remote_bda), 5, &instance->client->clientTaskHandle, 0);
-		
-		delay(1000);
-		
-		ESP_LOGI(LOG_TAG, "Set up client");
-		
-        if (instance->cbStateChanged) {
-        	instance->cbStateChanged(BLENotifications::StateConnected);
-        }
-    };
+		// instance->client->setStackSize(50000);
+		::xTaskCreatePinnedToCore(&ANCSBLEClient::startClientTask, "ClientTask", 10000, new BLEAddress(connectEventParam->remote_bda), 5, &instance->client->clientTaskHandle, 0);
 
-	void onDisconnect(BLEServer* pServer) {
-		  ::vTaskDelete(instance->client->clientTaskHandle);
-		  instance->client->clientTaskHandle = nullptr;
-			ESP_LOGI(LOG_TAG, "Device disconnected");
-	        if (instance->cbStateChanged) {
-	        	instance->cbStateChanged(BLENotifications::StateDisconnected);
-	        }
-			delete instance->client;
-			instance->client = nullptr;
-	    }
+		delay(1000);
+
+		ESP_LOGI(LOG_TAG, "Set up client");
+
+		if (instance->cbStateChanged)
+		{
+			instance->cbStateChanged(BLENotifications::StateConnected);
+		}
+	};
+
+	void onDisconnect(BLEServer *pServer)
+	{
+		::vTaskDelete(instance->client->clientTaskHandle);
+		instance->client->clientTaskHandle = nullptr;
+		ESP_LOGI(LOG_TAG, "Device disconnected");
+		if (instance->cbStateChanged)
+		{
+			instance->cbStateChanged(BLENotifications::StateDisconnected);
+		}
+		delete instance->client;
+		instance->client = nullptr;
+	}
 };
 
-
 BLENotifications::BLENotifications()
-	 : cbStateChanged(nullptr)
-	 , client(nullptr)
-	 , isAdvertising(false)
+		: cbStateChanged(nullptr), client(nullptr), isAdvertising(false)
 {
-	
 }
 
-const char * BLENotifications::getNotificationCategoryDescription(NotificationCategory category) const {
-	switch(category) { 
-    case CategoryIDOther: return "other";
-	case CategoryIDIncomingCall: return "incoming call";
-	case CategoryIDMissedCall: return "missed call";
-	case CategoryIDVoicemail: return "voicemail";
-	case CategoryIDSocial: return "social";
-	case CategoryIDSchedule: return "schedule";
-	case CategoryIDEmail: return "email";
-	case CategoryIDNews: return "news";
-	case CategoryIDHealthAndFitness: return "health and fitness";
-	case CategoryIDBusinessAndFinance: return "business and finance";
-	case CategoryIDLocation: return "location";
-	case CategoryIDEntertainment: return "entertainment";
-	default: return "unknown";
-}
+const char *BLENotifications::getNotificationCategoryDescription(NotificationCategory category) const
+{
+	switch (category)
+	{
+	case CategoryIDOther:
+		return "other";
+	case CategoryIDIncomingCall:
+		return "incoming call";
+	case CategoryIDMissedCall:
+		return "missed call";
+	case CategoryIDVoicemail:
+		return "voicemail";
+	case CategoryIDSocial:
+		return "social";
+	case CategoryIDSchedule:
+		return "schedule";
+	case CategoryIDEmail:
+		return "email";
+	case CategoryIDNews:
+		return "news";
+	case CategoryIDHealthAndFitness:
+		return "health and fitness";
+	case CategoryIDBusinessAndFinance:
+		return "business and finance";
+	case CategoryIDLocation:
+		return "location";
+	case CategoryIDEntertainment:
+		return "entertainment";
+	default:
+		return "unknown";
+	}
 }
 
-bool BLENotifications::begin(const char * name) {
+bool BLENotifications::begin(const char *name)
+{
 	ESP_LOGI(LOG_TAG, "begin()");
-    BLEDevice::init(name);
-    server = BLEDevice::createServer();
-    server->setCallbacks(new MyServerCallbacks(this));
-    BLEDevice::setEncryptionLevel(ESP_BLE_SEC_ENCRYPT);
+	BLEDevice::init(name);
+	server = BLEDevice::createServer();
+	server->setCallbacks(new MyServerCallbacks(this));
+	BLEDevice::setEncryptionLevel(ESP_BLE_SEC_ENCRYPT);
 	BLEDevice::setSecurityCallbacks(new NotificationSecurityCallbacks()); // @todo memory leak?
-	
+
 	startAdvertising();
 	return true;
 }
 
-bool BLENotifications::stop() {
+bool BLENotifications::stop()
+{
 	ESP_LOGI(LOG_TAG, "stop()");
 	BLEDevice::deinit(false);
 	return true;
 }
 
-
-void BLENotifications::setConnectionStateChangedCallback(ble_notifications_state_changed_t callback) {
+void BLENotifications::setConnectionStateChangedCallback(ble_notifications_state_changed_t callback)
+{
 	cbStateChanged = callback;
 }
 
-
-void BLENotifications::setNotificationCallback(ble_notification_arrived_t callback) {
+void BLENotifications::setNotificationCallback(ble_notification_arrived_t callback)
+{
 	cbNotification = callback;
 }
 
-void BLENotifications::setRemovedCallback(ble_notification_removed_t callback) {
-	cbRemoved = callback;	
+void BLENotifications::setRemovedCallback(ble_notification_removed_t callback)
+{
+	cbRemoved = callback;
 }
 
-void BLENotifications::actionPositive(uint32_t uuid) {
+void BLENotifications::actionPositive(uint32_t uuid)
+{
 	ESP_LOGI(LOG_TAG, "actionPositive()");
 	client->performAction(uuid, uint8_t(ANCS::NotificationActionPositive));
 }
 
-
-void BLENotifications::actionNegative(uint32_t uuid) {
+void BLENotifications::actionNegative(uint32_t uuid)
+{
 	ESP_LOGI(LOG_TAG, "actionNegative()");
 	client->performAction(uuid, uint8_t(ANCS::NotificationActionNegative));
 }
 
-void BLENotifications::startAdvertising() {
+void BLENotifications::startAdvertising()
+{
 	ESP_LOGI(LOG_TAG, "startAdvertising()");
-	
-    // Start soliciting the Apple ANCS service and make the device visible to searches on iOS (from Apple ANCS documentation)
-    BLEAdvertising *pAdvertising = BLEDevice::getAdvertising();
-	
-	if (isAdvertising == true) {
+
+	// Start soliciting the Apple ANCS service and make the device visible to searches on iOS (from Apple ANCS documentation)
+	BLEAdvertising *pAdvertising = BLEDevice::getAdvertising();
+
+	if (isAdvertising == true)
+	{
 		// Stopping it without checking first seems to cause failures to advertise without debugging on.
 		// There is no way to query the BLEAdvertising object to see if it is advertising, so we keep a variable.
 		pAdvertising->stop();
 	}
 
-    BLEAdvertisementData oAdvertisementData = BLEAdvertisementData();
-    oAdvertisementData.setFlags(0x01);
-	
+	BLEAdvertisementData oAdvertisementData = BLEAdvertisementData();
+	oAdvertisementData.setFlags(0x01);
+
 #ifdef BLE_LIB_HAS_SERVICE_SOLICITATION
-    oAdvertisementData.setServiceSolicitation(ANCSBLEClient::getAncsServiceUUID()); 
+	oAdvertisementData.setServiceSolicitation(ANCSBLEClient::getAncsServiceUUID());
 #else
 	setServiceSolicitation(oAdvertisementData, ANCSBLEClient::getAncsServiceUUID());
 #endif
-	
-    pAdvertising->setAdvertisementData(oAdvertisementData);        
 
-    // Set security
-    BLESecurity *pSecurity = new BLESecurity();
-    pSecurity->setAuthenticationMode(ESP_LE_AUTH_REQ_SC_BOND);
-    pSecurity->setCapability(ESP_IO_CAP_OUT);
-    pSecurity->setInitEncryptionKey(ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK);
+	pAdvertising->setAdvertisementData(oAdvertisementData);
 
-    //Start advertising
-    pAdvertising->start();
+	// Set security
+	BLESecurity *pSecurity = new BLESecurity();
+	pSecurity->setAuthenticationMode(ESP_LE_AUTH_REQ_SC_BOND);
+	pSecurity->setCapability(ESP_IO_CAP_OUT);
+	pSecurity->setInitEncryptionKey(ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK);
+
+	// Start advertising
+	pAdvertising->start();
 	isAdvertising = true;
 }
 
-
 #ifndef BLE_LIB_HAS_SERVICE_SOLICITATION
-void setServiceSolicitation(BLEAdvertisementData & advertisementData, BLEUUID uuid)
+void setServiceSolicitation(BLEAdvertisementData &advertisementData, BLEUUID uuid)
 {
 	char cdata[2];
-	switch(uuid.bitSize()) {
-		case 16: {
-			// [Len] [0x14] [UUID16] data
-			cdata[0] = 3;
-			cdata[1] = ESP_BLE_AD_TYPE_SOL_SRV_UUID;  // 0x14
-			advertisementData.addData(String(cdata, 2) + String((char *)&uuid.getNative()->uuid.uuid16,2));
-			break;
-		}
+	switch (uuid.bitSize())
+	{
+	case 16:
+	{
+		// [Len] [0x14] [UUID16] data
+		cdata[0] = 3;
+		cdata[1] = ESP_BLE_AD_TYPE_SOL_SRV_UUID; // 0x14
+		advertisementData.addData(String(cdata, 2) + String((char *)&uuid.getNative()->uuid.uuid16, 2));
+		break;
+	}
 
-		case 128: {
-			// [Len] [0x15] [UUID128] data
-			cdata[0] = 17;
-			cdata[1] = ESP_BLE_AD_TYPE_128SOL_SRV_UUID;  // 0x15
-			advertisementData.addData(String(cdata, 2) + String((char *)uuid.getNative()->uuid.uuid128,16));
-			break;
-		}
+	case 128:
+	{
+		// [Len] [0x15] [UUID128] data
+		cdata[0] = 17;
+		cdata[1] = ESP_BLE_AD_TYPE_128SOL_SRV_UUID; // 0x15
+		advertisementData.addData(String(cdata, 2) + String((char *)uuid.getNative()->uuid.uuid128, 16));
+		break;
+	}
 
-		default:
-			return;
+	default:
+		return;
 	}
 }
 #endif
-

--- a/src/esp32notifications.h
+++ b/src/esp32notifications.h
@@ -11,80 +11,79 @@
  * This class was designed with simplicity and ease-of-use in mind.
  * This library supports ESP32 debugging output: in the Arduino IDE, change Tools/Core Debug Level.
  */
-class BLENotifications {
-    public:
-        /**
-         * State of the BLE connection.
-         */
-        enum State {
-            StateConnected,     /**< A device connected to the ESP32. */
-            StateDisconnected   /**< A device disconnected from the ESP32. Note that you should call startAdvertising after this message.*/
-        };
-        
-        /**
-         * Callback for a state change of the BLE connection.
-         * Use this to modify the UI to notify the user if a connection is available.
-         */
-        typedef void (*ble_notifications_state_changed_t)(State state);
+class BLENotifications
+{
+public:
+    /**
+     * State of the BLE connection.
+     */
+    enum State
+    {
+        StateConnected,   /**< A device connected to the ESP32. */
+        StateDisconnected /**< A device disconnected from the ESP32. Note that you should call startAdvertising after this message.*/
+    };
 
+    /**
+     * Callback for a state change of the BLE connection.
+     * Use this to modify the UI to notify the user if a connection is available.
+     */
+    typedef void (*ble_notifications_state_changed_t)(State state);
 
-    public:
-        BLENotifications();
-        
-        /**
-         * Setup the device to receive BLE notifications.
-         * Will also automatically start advertising.
-         * @param name the device name, as it will appear in a BLE scan.
-         */
-        bool begin(const char * name);
-        
-        /**
-         * Make this device visible in scans as available for connection.
-         * Will stop the current advertisement if it is running.
-         */
-        void startAdvertising();
-        
-        /**
-         * Shutdown BLE and free memory.
-         * Note that currently the BLE library internals do not seem to restore state properly, so the BLE library
-         * cannot be used after a stop.
-         * 
-         */
-        bool stop();
-        
-        /**
-         * Set this to a callback for when the BLE connects or disconnects.
-         */
-        void setConnectionStateChangedCallback(ble_notifications_state_changed_t);
-        
-        /**
-         * Set this to a callback for when a notification arrives.
-         */
-        void setNotificationCallback(ble_notification_arrived_t);
-        void setRemovedCallback(ble_notification_removed_t);
+public:
+    BLENotifications();
 
-        void actionPositive(uint32_t uuid);
-        void actionNegative(uint32_t uuid);
-    
-        /** 
-         * Given a category, return a description of the category in English
-        */
-        const char * getNotificationCategoryDescription(NotificationCategory category) const;
+    /**
+     * Setup the device to receive BLE notifications.
+     * Will also automatically start advertising.
+     * @param name the device name, as it will appear in a BLE scan.
+     */
+    bool begin(const char *name);
 
-	private:
+    /**
+     * Make this device visible in scans as available for connection.
+     * Will stop the current advertisement if it is running.
+     */
+    void startAdvertising();
 
-        
-    private:
-        ble_notifications_state_changed_t cbStateChanged;
-        ble_notification_arrived_t cbNotification;
-        ble_notification_removed_t cbRemoved;
-        
-        class BLEServer* server;
-        class ANCSBLEClient* client;
-        
-        bool isAdvertising;
-        
-        friend class MyServerCallbacks; //Allow internal handlers to access the callbacks of the main class
+    /**
+     * Shutdown BLE and free memory.
+     * Note that currently the BLE library internals do not seem to restore state properly, so the BLE library
+     * cannot be used after a stop.
+     *
+     */
+    bool stop();
+
+    /**
+     * Set this to a callback for when the BLE connects or disconnects.
+     */
+    void setConnectionStateChangedCallback(ble_notifications_state_changed_t);
+
+    /**
+     * Set this to a callback for when a notification arrives.
+     */
+    void setNotificationCallback(ble_notification_arrived_t);
+    void setRemovedCallback(ble_notification_removed_t);
+
+    void actionPositive(uint32_t uuid);
+    void actionNegative(uint32_t uuid);
+
+    /**
+     * Given a category, return a description of the category in English
+     */
+    const char *getNotificationCategoryDescription(NotificationCategory category) const;
+
+private:
+private:
+    ble_notifications_state_changed_t cbStateChanged;
+    ble_notification_arrived_t cbNotification;
+    ble_notification_removed_t cbRemoved;
+
+    class BLEServer *server;
+    class ANCSBLEClient *client;
+
+    bool isAdvertising;
+
+    friend class MyServerCallbacks; // Allow internal handlers to access the callbacks of the main class
 };
 
 #endif // ESP32NOTIFICATIONS_H_


### PR DESCRIPTION
## Notes

Library currently does not compile due to missing `time_t` type. It also connects briefly before disconnecting and does not receive any notifications.

This PR fixes both bugs. It:
- Includes `time.h` header file in `ble_notification.h`
- Passes in `param->connect.remote_bda` instead of incorrectly casted `connectEventParam->remote_bda` to ANCSBLEClient

It also whitespace autoformats all files and updates the minimal README example

## Testing

Pulled my fork into Arduino/library and uploaded`ble_connection.ino` example to ESP32. Connected to ESP32 in nRF app from iPhone and was able to successfully see push notifications in serial monitor:

<img width="610" alt="Screenshot 2025-02-20 at 1 33 20 AM" src="https://github.com/user-attachments/assets/e1e5d64b-465b-4b15-bf95-08d8ddbd90a5" />