### PR TITLE
fix(ios): improve discoverability and ANCS bonding

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This library is designed to follow the standard Arduino library style, and be as
   + Easily start re-advertising the ESP 32 device if BLE connection is lost.
   + Apple ANCS notification support, with advanced message details.
   + Use actions to accept or reject incoming calls.
+  + iOS Settings visibility improvements (local name in primary ADV + adopted 16-bit service UUID).
+  + Forces bonding/encryption on connect to trigger the iOS "Allow Notifications" prompt.
 
 
 ## Installation
@@ -91,6 +93,15 @@ Note that the Espressif BLE libraries are very large, so you may need to increas
 
 See the ble_connection example for a more fully-featured example.
 
+## iOS Notes (Local Fork)
+
+This fork adjusts BLE advertising and security to improve iOS pairing and discoverability:
+
+- **Discoverability in iOS Settings**: iOS often uses passive scans and ignores scan response data. The local name is placed in the **primary advertisement** and a 16-bit adopted service UUID (Heart Rate, `0x180D`) is advertised to increase the chance of showing in **Settings → Bluetooth**.
+- **ANCS permission prompt**: ANCS requires an encrypted/bonded link. The server forces encryption on connect and uses **Just-Works bonding** (`ESP_LE_AUTH_BOND` + `ESP_IO_CAP_NONE`) to make pairing reliable.
+
+If you previously paired and no permission prompt appears, "Forget" the device in iOS and re-pair.
+
 
 
 
@@ -99,4 +110,3 @@ See the ble_connection example for a more fully-featured example.
 Based on the work of CarWatch, Hackwatch, and S-March. This project was created to hide the complicated BLE notification internals behind a standard, easy-to-use Arduino library.
 
 To see a real-world project, https://github.com/jhud/hackwatch uses this library.
-

--- a/examples/iphone_notifications/iphone_notifications.ino
+++ b/examples/iphone_notifications/iphone_notifications.ino
@@ -1,0 +1,104 @@
+/*
+Minimal iPhone ANCS notification example for ESP32.
+
+Steps:
+1) Boot ESP32 with pairing button held (GPIO33 to GND).
+2) iPhone: Settings → Bluetooth → pair with "beepr-ancs".
+3) Accept pairing and "Allow Notifications" prompt.
+4) Reboot ESP32 without the button for normal mode.
+*/
+
+#include <Arduino.h>
+#include "esp32notifications.h"
+
+static const int PAIRING_PIN = 33;
+static const char *DEVICE_NAME = "beepr-ancs";
+
+BLENotifications notifications;
+
+static void onBLEStateChanged(BLENotifications::State state)
+{
+    switch (state)
+    {
+    case BLENotifications::StateConnected:
+        Serial.println("Connected");
+        Serial.println("ANCS client starting (subscribing)");
+        break;
+    case BLENotifications::StateDisconnected:
+        Serial.println("Disconnected");
+        notifications.startAdvertising();
+        Serial.println("Advertising started");
+        break;
+    }
+}
+
+static void onNotificationArrived(const ArduinoNotification *notification, const Notification *rawNotificationData)
+{
+    (void)rawNotificationData;
+    if (notification->uuid == 0 && notification->type.length() == 0 &&
+        notification->title.length() == 0 && notification->message.length() == 0)
+    {
+        return;
+    }
+
+    Serial.println("Notification received");
+    Serial.printf("App: %s\n", notification->type.length() ? notification->type.c_str() : "(unknown)");
+    Serial.printf("Title: %s\n", notification->title.length() ? notification->title.c_str() : "(none)");
+    Serial.printf("Message: %s\n", notification->message.length() ? notification->message.c_str() : "(none)");
+    if (notification->time != 0)
+    {
+        Serial.printf("Date: %lu\n", (unsigned long)notification->time);
+    }
+    else
+    {
+        Serial.println("Date: (not provided)");
+    }
+    Serial.printf("Category: %s\n", notifications.getNotificationCategoryDescription(notification->category));
+    Serial.printf("CategoryCount: %u\n", notification->categoryCount);
+    Serial.printf("UUID: %lu\n", (unsigned long)notification->uuid);
+}
+
+static void onNotificationRemoved(const ArduinoNotification *notification, const Notification *rawNotificationData)
+{
+    (void)rawNotificationData;
+    if (notification->uuid == 0 && notification->type.length() == 0 &&
+        notification->title.length() == 0 && notification->message.length() == 0)
+    {
+        return;
+    }
+    Serial.println("Notification removed");
+    Serial.printf("App: %s\n", notification->type.length() ? notification->type.c_str() : "(unknown)");
+    Serial.printf("Title: %s\n", notification->title.length() ? notification->title.c_str() : "(none)");
+    Serial.printf("Message: %s\n", notification->message.length() ? notification->message.c_str() : "(none)");
+}
+
+void setup()
+{
+    pinMode(PAIRING_PIN, INPUT_PULLUP);
+    bool pairingMode = (digitalRead(PAIRING_PIN) == LOW);
+
+    Serial.begin(115200);
+    delay(200);
+
+    if (pairingMode)
+    {
+        Serial.println("PAIRING MODE (GPIO33=LOW)");
+    }
+    else
+    {
+        Serial.println("NORMAL MODE (GPIO33=HIGH)");
+    }
+
+    notifications.begin(DEVICE_NAME);
+    notifications.setConnectionStateChangedCallback(onBLEStateChanged);
+    notifications.setNotificationCallback(onNotificationArrived);
+    notifications.setRemovedCallback(onNotificationRemoved);
+
+    notifications.startAdvertising();
+    Serial.println("Advertising started");
+}
+
+void loop()
+{
+    delay(250);
+}

--- a/examples/iphone_notifications/iphone_notifications.ino
+++ b/examples/iphone_notifications/iphone_notifications.ino
@@ -1,6 +1,5 @@
 /*
 Minimal iPhone ANCS notification example for ESP32.
-
 Steps:
 1) Boot ESP32 with pairing button held (GPIO33 to GND).
 2) iPhone: Settings → Bluetooth → pair with "beepr-ancs".

--- a/src/ancs_ble_client.cpp
+++ b/src/ancs_ble_client.cpp
@@ -82,8 +82,8 @@ void ANCSBLEClient::setup(const BLEAddress *address)
 	BLEDevice::setSecurityCallbacks(new NotificationSecurityCallbacks()); // @todo memory leak?
 
 	BLESecurity *pSecurity = new BLESecurity();
-	pSecurity->setAuthenticationMode(ESP_LE_AUTH_REQ_SC_BOND);
-	pSecurity->setCapability(ESP_IO_CAP_IO);
+	pSecurity->setAuthenticationMode(ESP_LE_AUTH_BOND);
+	pSecurity->setCapability(ESP_IO_CAP_NONE);
 	pSecurity->setRespEncryptionKey(ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK);
 	// Connect to the remote BLE Server.
 	if (!pClient->connect(*address))

--- a/src/ancs_ble_client.cpp
+++ b/src/ancs_ble_client.cpp
@@ -24,6 +24,35 @@ const BLEUUID ancsServiceUUID("7905F431-B5CE-4E99-A40F-4B1E122D00D0");
 
 static ANCSBLEClient *sharedInstance;
 
+static int64_t daysFromCivil(int y, unsigned m, unsigned d)
+{
+	y -= m <= 2;
+	const int era = (y >= 0 ? y : y - 399) / 400;
+	const unsigned yoe = (unsigned)(y - era * 400);
+	const unsigned doy = (153 * (m + (m > 2 ? -3 : 9)) + 2) / 5 + d - 1;
+	const unsigned doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+	return (int64_t)(era * 146097 + (int)doe - 719468);
+}
+
+static time_t parseAncsDate(const std::string &dateStr)
+{
+	if (dateStr.size() < 15)
+	{
+		return 0;
+	}
+
+	int y = (dateStr[0] - '0') * 1000 + (dateStr[1] - '0') * 100 + (dateStr[2] - '0') * 10 + (dateStr[3] - '0');
+	unsigned m = (dateStr[4] - '0') * 10 + (dateStr[5] - '0');
+	unsigned d = (dateStr[6] - '0') * 10 + (dateStr[7] - '0');
+	unsigned hh = (dateStr[9] - '0') * 10 + (dateStr[10] - '0');
+	unsigned mm = (dateStr[11] - '0') * 10 + (dateStr[12] - '0');
+	unsigned ss = (dateStr[13] - '0') * 10 + (dateStr[14] - '0');
+
+	int64_t days = daysFromCivil(y, m, d);
+	int64_t seconds = days * 86400 + hh * 3600 + mm * 60 + ss;
+	return (time_t)seconds;
+}
+
 static void dataSourceNotifyCallback(
 		BLERemoteCharacteristic *pDataSourceCharacteristic,
 		uint8_t *pData,
@@ -213,6 +242,10 @@ void ANCSBLEClient::onDataSourceNotify(
 	case 0x3:
 		notification->message = message;
 		ESP_LOGD(LOG_TAG, "got message: %s", message.c_str());
+		break;
+	case ANCS::NotificationAttributeIDDate:
+		notification->time = parseAncsDate(message);
+		ESP_LOGD(LOG_TAG, "got date: %s", message.c_str());
 		break;
 	}
 	if (!notification->title.empty() && !notification->message.empty())

--- a/src/ancs_ble_client.cpp
+++ b/src/ancs_ble_client.cpp
@@ -45,7 +45,7 @@ static void notificationSourceNotifyCallback(
 }
 
 ANCSBLEClient::ANCSBLEClient()
-		: notificationCB(nullptr), removedCB(nullptr), pControlPointCharacteristic(nullptr)
+		: notificationCB(nullptr), removedCB(nullptr), pControlPointCharacteristic(nullptr), pClient(nullptr)
 {
 	assert(sharedInstance == nullptr);
 	sharedInstance = this;
@@ -78,7 +78,7 @@ void ANCSBLEClient::startClientTask(void *params)
 
 void ANCSBLEClient::setup(const BLEAddress *address)
 {
-	BLEClient *pClient = BLEDevice::createClient();
+	pClient = BLEDevice::createClient();
 	BLEDevice::setSecurityCallbacks(new NotificationSecurityCallbacks()); // @todo memory leak?
 
 	BLESecurity *pSecurity = new BLESecurity();
@@ -127,6 +127,15 @@ void ANCSBLEClient::setup(const BLEAddress *address)
 	pDataSourceCharacteristic->getDescriptor(BLEUUID((uint16_t)0x2902))->writeValue((uint8_t *)v, 2, true);
 	pNotificationSourceCharacteristic->registerForNotify(notificationSourceNotifyCallback);
 	pNotificationSourceCharacteristic->getDescriptor(BLEUUID((uint16_t)0x2902))->writeValue((uint8_t *)v, 2, true);
+}
+
+void ANCSBLEClient::keepAlive()
+{
+	if (pClient && pClient->isConnected())
+	{
+		// Read RSSI as a minimal keep-alive that doesn't modify ANCS behavior.
+		(void)pClient->getRssi();
+	}
 }
 
 BLEUUID ANCSBLEClient::getAncsServiceUUID()

--- a/src/ancs_ble_client.h
+++ b/src/ancs_ble_client.h
@@ -29,6 +29,8 @@ public:
 	void setNotificationRemovedCallback(ble_notification_removed_t cbNotification);
 
 	void performAction(uint32_t notifyUUID, uint8_t actionID);
+	// Lightweight keep-alive: read RSSI to keep link active without changing ANCS behavior.
+	void keepAlive();
 
 public:
 	static BLEUUID getAncsServiceUUID(); // To be able to advertise it
@@ -65,6 +67,7 @@ private:
 	ble_notification_removed_t removedCB;
 
 	class BLERemoteCharacteristic *pControlPointCharacteristic;
+	class BLEClient *pClient;
 };
 
 #endif // ANCS_BLE_CLIENT_H_

--- a/src/esp32notifications.cpp
+++ b/src/esp32notifications.cpp
@@ -159,6 +159,14 @@ void BLENotifications::actionNegative(uint32_t uuid)
 	client->performAction(uuid, uint8_t(ANCS::NotificationActionNegative));
 }
 
+void BLENotifications::keepAlive()
+{
+	if (client)
+	{
+		client->keepAlive();
+	}
+}
+
 void BLENotifications::startAdvertising()
 {
 	ESP_LOGI(LOG_TAG, "startAdvertising()");

--- a/src/esp32notifications.cpp
+++ b/src/esp32notifications.cpp
@@ -18,6 +18,7 @@
 #include "BLE2902.h"
 
 #include <esp_gatts_api.h>
+#include <esp_gap_ble_api.h>
 
 static char LOG_TAG[] = "BLENotifications";
 
@@ -26,6 +27,7 @@ extern const BLEUUID ancsServiceUUID;
 #ifndef BLE_LIB_HAS_SERVICE_SOLICITATION
 // Use a static function, instead of doing a whole private implementation just for a this one small patch.
 static void setServiceSolicitation(class BLEAdvertisementData &advertisementData, BLEUUID uuid);
+static void add16BitServiceUUID(class BLEAdvertisementData &advertisementData, uint16_t uuid16);
 #endif
 
 class MyServerCallbacks : public BLEServerCallbacks
@@ -42,6 +44,7 @@ public:
 	void onConnect(BLEServer *pServer, esp_ble_gatts_cb_param_t *param)
 	{
 		ESP_LOGI(LOG_TAG, "Device connected");
+		esp_ble_set_encryption(param->connect.remote_bda, ESP_BLE_SEC_ENCRYPT);
 		instance->client = new ANCSBLEClient(); // @todo memory leaks?
 		instance->client->setNotificationArrivedCallback(instance->cbNotification);
 		instance->client->setNotificationRemovedCallback(instance->cbRemoved);
@@ -72,7 +75,7 @@ public:
 };
 
 BLENotifications::BLENotifications()
-		: cbStateChanged(nullptr), client(nullptr), isAdvertising(false)
+		: cbStateChanged(nullptr), client(nullptr), isAdvertising(false), deviceName(nullptr)
 {
 }
 
@@ -112,6 +115,7 @@ const char *BLENotifications::getNotificationCategoryDescription(NotificationCat
 bool BLENotifications::begin(const char *name)
 {
 	ESP_LOGI(LOG_TAG, "begin()");
+	deviceName = name;
 	BLEDevice::init(name);
 	server = BLEDevice::createServer();
 	server->setCallbacks(new MyServerCallbacks(this));
@@ -170,23 +174,29 @@ void BLENotifications::startAdvertising()
 	}
 
 	BLEAdvertisementData oAdvertisementData = BLEAdvertisementData();
-	oAdvertisementData.setFlags(0x01);
+	oAdvertisementData.setFlags(0x06);
+	if (deviceName)
+	{
+		oAdvertisementData.setName(deviceName);
+	}
+	add16BitServiceUUID(oAdvertisementData, 0x180D);
 
+	BLEAdvertisementData oScanResponseData = BLEAdvertisementData();
 #ifdef BLE_LIB_HAS_SERVICE_SOLICITATION
-	oAdvertisementData.setServiceSolicitation(ANCSBLEClient::getAncsServiceUUID());
+	oScanResponseData.setServiceSolicitation(ANCSBLEClient::getAncsServiceUUID());
 #else
-	setServiceSolicitation(oAdvertisementData, ANCSBLEClient::getAncsServiceUUID());
+	setServiceSolicitation(oScanResponseData, ANCSBLEClient::getAncsServiceUUID());
 #endif
 
 	pAdvertising->setAdvertisementData(oAdvertisementData);
+	pAdvertising->setScanResponseData(oScanResponseData);
+	pAdvertising->setScanResponse(true);
 
-	// Set security
 	BLESecurity *pSecurity = new BLESecurity();
-	pSecurity->setAuthenticationMode(ESP_LE_AUTH_REQ_SC_BOND);
-	pSecurity->setCapability(ESP_IO_CAP_OUT);
+	pSecurity->setAuthenticationMode(ESP_LE_AUTH_BOND);
+	pSecurity->setCapability(ESP_IO_CAP_NONE);
 	pSecurity->setInitEncryptionKey(ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK);
 
-	// Start advertising
 	pAdvertising->start();
 	isAdvertising = true;
 
@@ -220,5 +230,13 @@ void setServiceSolicitation(BLEAdvertisementData &advertisementData, BLEUUID uui
 	default:
 		return;
 	}
+}
+
+void add16BitServiceUUID(BLEAdvertisementData &advertisementData, uint16_t uuid16)
+{
+	char cdata[2];
+	cdata[0] = 3;
+	cdata[1] = ESP_BLE_AD_TYPE_16SRV_CMPL; // 0x03
+	advertisementData.addData(String(cdata, 2) + String((char *)&uuid16, 2));
 }
 #endif

--- a/src/esp32notifications.h
+++ b/src/esp32notifications.h
@@ -82,6 +82,7 @@ private:
     class ANCSBLEClient *client;
 
     bool isAdvertising;
+    const char *deviceName;
 
     friend class MyServerCallbacks; // Allow internal handlers to access the callbacks of the main class
 };

--- a/src/esp32notifications.h
+++ b/src/esp32notifications.h
@@ -66,6 +66,8 @@ public:
 
     void actionPositive(uint32_t uuid);
     void actionNegative(uint32_t uuid);
+    // Optional keep-alive to reduce idle disconnects.
+    void keepAlive();
 
     /**
      * Given a category, return a description of the category in English


### PR DESCRIPTION

## Summary
Advertising and security behavior were updated to make iOS Settings reliably list the device and to ensure bonding/encryption completes so ANCS permission prompts appear. A minimal, energy‑aware keep‑alive was added to reduce idle disconnects.

## Changes

1) **General discoverable advertising flags**
   - Set flags to `0x06` (LE General Discoverable + BR/EDR Not Supported).
   - Improves device visibility in iOS Settings.

2) **Local name in primary advertisement**
   - Store `deviceName` in `BLENotifications` and include it in the primary ADV.
   - iOS Settings often ignores scan response; the name must be in the main packet.

3) **Advertise an adopted 16‑bit service UUID (0x180D)**
   - Adds Heart Rate service UUID in the primary ADV for discoverability.
   - Implemented using raw AD structure helper `add16BitServiceUUID(...)` for compatibility.

4) **ANCS Service Solicitation moved to scan response**
   - Keeps primary ADV small and focused while still soliciting ANCS.

5) **Force encryption on connect**
   - Calls `esp_ble_set_encryption(...)` on connect to trigger pairing/bonding.

6) **Use Just‑Works bonding (no IO)**
   - Set authentication to `ESP_LE_AUTH_BOND` and capability to `ESP_IO_CAP_NONE`.
   - Avoids issues with Secure Connections + IO capabilities during pairing.

7) **Store device name in class**
   - Added `deviceName` member to reuse the name later (BLE stack lacks `BLEDevice::getName()`).

8) **Minimal keep‑alive API**
   - Added `keepAlive()` in `ANCSBLEClient` and `BLENotifications`.
   - Implementation reads RSSI when connected to reduce idle disconnects without changing ANCS behavior.

## Files Modified
- `src/esp32notifications.cpp`
- `src/esp32notifications.h`
- `src/ancs_ble_client.cpp`
- `src/ancs_ble_client.h`
- `examples/iphone_notifications/iphone_notifications.ino`